### PR TITLE
Ordena emoções por data de criação em grupos diários

### DIFF
--- a/src/backend/backend/Services/EmotionService.cs
+++ b/src/backend/backend/Services/EmotionService.cs
@@ -85,7 +85,7 @@ namespace backend.Services
         public async Task<IEnumerable<EmotionDailyGroupResponse>> GetThisWeekAsync(Guid userId)
         {
             var list = await _repository.GetThisWeekAsync(userId);
-            
+
             return list
                 .GroupBy(e => e.CreatedAt.Date)
                 .Select(g => new EmotionDailyGroupResponse
@@ -98,10 +98,11 @@ namespace backend.Services
                         Mood = e.Emotion.ToString(),
                         CreatedAt = e.CreatedAt,
                         Diary = e.Diary
-                    }).ToList()
+                    })
+                    .OrderBy(e => e.CreatedAt)
+                    .ToList()
                 })
-                .OrderBy(g => g.Date)
-                .ToList();
+                .OrderBy(d => d.Date);
         }
     }
 }


### PR DESCRIPTION
Agora as emoções são ordenadas por CreatedAt dentro de cada grupo diário no método GetThisWeekAsync. A ordenação dos grupos por data foi mantida, mas o método retorna um IEnumerable ao invés de uma lista concreta, removendo o uso de ToList() ao final.

<img width="721" height="525" alt="Captura de tela 2026-05-07 204512" src="https://github.com/user-attachments/assets/3efe3f52-8bf1-4159-9078-44095fb2cb7a" />