### PR TITLE
Implementa histórico diário de conversas no chat

### DIFF
--- a/src/backend/backend/Controllers/ChatController.cs
+++ b/src/backend/backend/Controllers/ChatController.cs
@@ -1,6 +1,8 @@
 using backend.DTOs;
 using backend.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace backend.Controllers;
 
@@ -8,7 +10,8 @@ namespace backend.Controllers;
 // All orchestration stays in the application service to keep the controller easy to test.
 [ApiController]
 [Route("api/chat")]
-public sealed class ChatController : ControllerBase
+[Authorize]
+public class ChatController : ControllerBase
 {
     private readonly IChatAssistantService _chatAssistantService;
 
@@ -20,7 +23,25 @@ public sealed class ChatController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<ChatResponse>> SendMessage([FromBody] ChatRequest request, CancellationToken cancellationToken)
     {
-        var response = await _chatAssistantService.SendAsync(request, cancellationToken);
+        var userId = GetUserIdFromClaims();
+        var response = await _chatAssistantService.SendAsync(request, userId, cancellationToken);
         return Ok(response);
+    }
+
+    [HttpGet("history")]
+    public async Task<ActionResult<ChatHistoryResponse>> GetTodayMessages()
+    {
+        var userId = GetUserIdFromClaims();
+        var response = await _chatAssistantService.GetMessagesAsync(userId);
+        return Ok(response);
+    }
+
+    private Guid GetUserIdFromClaims()
+    {
+        var idClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(idClaim) || !Guid.TryParse(idClaim, out var userId))
+            throw new UnauthorizedAccessException("Invalid user");
+
+        return userId;
     }
 }

--- a/src/backend/backend/DTOs/ChatHistoryResponse.cs
+++ b/src/backend/backend/DTOs/ChatHistoryResponse.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace backend.DTOs
+{
+    public sealed class ChatHistoryMessageDto
+    {
+        public Guid Id { get; set; }
+        public string Role { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+    }
+
+    public sealed class ChatHistoryResponse
+    {
+        public List<ChatHistoryMessageDto> Messages { get; set; } = new List<ChatHistoryMessageDto>();
+    }
+}

--- a/src/backend/backend/DTOs/ChatRequest.cs
+++ b/src/backend/backend/DTOs/ChatRequest.cs
@@ -14,5 +14,5 @@ public sealed class ChatRequest
     [MinLength(1)]
     public string Message { get; set; } = string.Empty;
 
-    public List<ChatMessage> History { get; set; } = [];
+    public List<ChatMessage> History { get; set; } = new List<ChatMessage>();
 }

--- a/src/backend/backend/Data/AppDbContext.cs
+++ b/src/backend/backend/Data/AppDbContext.cs
@@ -15,11 +15,30 @@ namespace backend.Data
         public DbSet<EmotionLog> Emotions { get; set; }
         public DbSet<UserOnboarding> UserOnboardings { get; set; }
         public DbSet<BreathingLog> BreathingLogs { get; set; }
+        public DbSet<Conversation> Conversations { get; set; }
+        public DbSet<ConversationMessage> ConversationMessages { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<EmotionLog>()
                 .Property(e => e.Emotion)
                 .HasConversion<string>();
+
+            modelBuilder.Entity<Conversation>(b =>
+            {
+                b.HasKey(c => c.Id);
+                b.Property(c => c.Date).IsRequired();
+                b.HasIndex(c => new { c.UserId, c.Date }).IsUnique();
+                b.HasMany(c => c.Messages).WithOne(m => m.Conversation).HasForeignKey(m => m.ConversationId);
+            });
+
+            modelBuilder.Entity<ConversationMessage>(b =>
+            {
+                b.HasKey(m => m.Id);
+                b.Property(m => m.Role).IsRequired();
+                b.Property(m => m.Content).IsRequired();
+                b.Property(m => m.Timestamp).IsRequired();
+            });
         }
     }
 }

--- a/src/backend/backend/Entities/Conversation.cs
+++ b/src/backend/backend/Entities/Conversation.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace backend.Entities
+{
+    public class Conversation
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        // Date only (UTC date) representing the day of the conversation
+        public DateTime Date { get; set; }
+
+        public Guid UserId { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public ICollection<ConversationMessage> Messages { get; set; } = new List<ConversationMessage>();
+    }
+}

--- a/src/backend/backend/Entities/ConversationMessage.cs
+++ b/src/backend/backend/Entities/ConversationMessage.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace backend.Entities
+{
+    public class ConversationMessage
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        public Guid ConversationId { get; set; }
+        public Conversation Conversation { get; set; } = null!;
+
+        public string Role { get; set; } = string.Empty; // "user" or "assistant"
+
+        public string Content { get; set; } = string.Empty;
+
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/src/backend/backend/Infrastructure/Interfaces/IChatAssistantService.cs
+++ b/src/backend/backend/Infrastructure/Interfaces/IChatAssistantService.cs
@@ -5,5 +5,6 @@ namespace backend.Infrastructure.Interfaces;
 // Orchestrates user input, provider selection and prompt assembly.
 public interface IChatAssistantService
 {
-    Task<ChatResponse> SendAsync(ChatRequest request, CancellationToken cancellationToken = default);
+    Task<ChatHistoryResponse> GetMessagesAsync(Guid userId);
+    Task<ChatResponse> SendAsync(ChatRequest request, Guid userId, CancellationToken cancellationToken = default);
 }

--- a/src/backend/backend/Infrastructure/RepositoriesExtensions.cs
+++ b/src/backend/backend/Infrastructure/RepositoriesExtensions.cs
@@ -1,0 +1,14 @@
+using backend.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace backend.Infrastructure
+{
+    public static class RepositoriesExtensions
+    {
+        public static IServiceCollection AddRepositories(this IServiceCollection services)
+        {
+            services.AddScoped<IConversationRepository, ConversationRepository>();
+            return services;
+        }
+    }
+}

--- a/src/backend/backend/Migrations/20260611150554_AddTablesChatConversations.Designer.cs
+++ b/src/backend/backend/Migrations/20260611150554_AddTablesChatConversations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using backend.Data;
 
@@ -11,9 +12,11 @@ using backend.Data;
 namespace backend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611150554_AddTablesChatConversations")]
+    partial class AddTablesChatConversations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/backend/Migrations/20260611150554_AddTablesChatConversations.cs
+++ b/src/backend/backend/Migrations/20260611150554_AddTablesChatConversations.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTablesChatConversations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Conversations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Conversations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ConversationMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ConversationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Role = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Content = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Timestamp = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConversationMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ConversationMessages_Conversations_ConversationId",
+                        column: x => x.ConversationId,
+                        principalTable: "Conversations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConversationMessages_ConversationId",
+                table: "ConversationMessages",
+                column: "ConversationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Conversations_UserId_Date",
+                table: "Conversations",
+                columns: new[] { "UserId", "Date" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ConversationMessages");
+
+            migrationBuilder.DropTable(
+                name: "Conversations");
+        }
+    }
+}

--- a/src/backend/backend/Program.cs
+++ b/src/backend/backend/Program.cs
@@ -6,6 +6,7 @@ using backend.Infrastructure.Interfaces;
 using backend.Middleware;
 using backend.Repositories;
 using backend.Services;
+using backend.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -79,6 +80,9 @@ builder.Services.AddScoped<IAIProviderFactory, AIProviderFactory>();
 builder.Services.AddScoped<IChatAssistantService, ChatAssistantService>();
 builder.Services.AddScoped<IPromptService, PromptService>();
 
+// Register IHttpContextAccessor for accessing user id in services
+builder.Services.AddHttpContextAccessor();
+
 // Token service
 builder.Services.AddScoped<TokenService>();
 
@@ -89,6 +93,9 @@ builder.Services.AddScoped<IBreathingRepository, BreathingRepository>();
 builder.Services.AddScoped<IBreathingService, BreathingService>();
 builder.Services.AddScoped<IUserOnboardingRepository, UserOnboardingRepository>();
 builder.Services.AddScoped<IUserOnboardingService, UserOnboardingService>();
+
+// Conversations
+builder.Services.AddRepositories();
 
 // Jwt Authentication
 var key = Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"] ?? string.Empty);

--- a/src/backend/backend/Repositories/ConversationRepository.cs
+++ b/src/backend/backend/Repositories/ConversationRepository.cs
@@ -1,0 +1,67 @@
+using backend.Data;
+using backend.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace backend.Repositories
+{
+    public interface IConversationRepository
+    {
+        Task<Conversation?> GetTodayConversationAsync(Guid userId);
+        Task<Conversation> CreateConversationAsync(Guid userId, DateTime date);
+        Task AddMessageAsync(ConversationMessage message);
+        Task<List<ConversationMessage>> GetMessagesForConversationAsync(Guid conversationId);
+        Task SaveChangesAsync();
+    }
+
+    public class ConversationRepository : IConversationRepository
+    {
+        private readonly AppDbContext _db;
+
+        public ConversationRepository(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<Conversation?> GetTodayConversationAsync(Guid userId)
+        {
+            var utcToday = DateTime.UtcNow.Date;
+            return await _db.Conversations
+                .Include(c => c.Messages)
+                .Where(c => c.UserId == userId && c.Date == utcToday)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<Conversation> CreateConversationAsync(Guid userId, DateTime date)
+        {
+            var conv = new Conversation
+            {
+                UserId = userId,
+                Date = date,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _db.Conversations.Add(conv);
+            await _db.SaveChangesAsync();
+            return conv;
+        }
+
+        public async Task AddMessageAsync(ConversationMessage message)
+        {
+            _db.ConversationMessages.Add(message);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task<List<ConversationMessage>> GetMessagesForConversationAsync(Guid conversationId)
+        {
+            return await _db.ConversationMessages
+                .Where(m => m.ConversationId == conversationId)
+                .OrderBy(m => m.Timestamp)
+                .ToListAsync();
+        }
+
+        public async Task SaveChangesAsync()
+        {
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/backend/backend/Services/ChatAssistantService.cs
+++ b/src/backend/backend/Services/ChatAssistantService.cs
@@ -1,8 +1,12 @@
 using backend.DTOs;
 using backend.Entities;
 using backend.Infrastructure.Interfaces;
+using backend.Repositories;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using System.IO;
+using System.Linq;
+using System.Security.Claims;
 
 namespace backend.Services; 
 
@@ -14,20 +18,49 @@ public sealed class ChatAssistantService : IChatAssistantService
     private readonly AIOptions _aiOptions;
     private readonly ILogger<ChatAssistantService> _logger;
     private readonly IPromptService _promptService;
+    private readonly IConversationRepository _conversationRepository;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
     public ChatAssistantService(
         IAIProviderFactory providerFactory,
         IOptions<AIOptions> aiOptions,
         ILogger<ChatAssistantService> logger,
-        IPromptService promptService)
+        IPromptService promptService,
+        IConversationRepository conversationRepository,
+        IHttpContextAccessor httpContextAccessor)
     {
         _providerFactory = providerFactory;
         _aiOptions = aiOptions.Value;
         _logger = logger;
         _promptService = promptService;
+        _conversationRepository = conversationRepository;
+        _httpContextAccessor = httpContextAccessor;
     }
 
-    public async Task<ChatResponse> SendAsync(ChatRequest request, CancellationToken cancellationToken = default)
+    public async Task<ChatHistoryResponse> GetMessagesAsync(Guid userId)
+    {
+        var conversation = await _conversationRepository.GetTodayConversationAsync(userId);
+
+        if (conversation == null)
+        {
+            return new ChatHistoryResponse();
+        }
+
+        var messages = await _conversationRepository.GetMessagesForConversationAsync(conversation.Id);
+
+        return new ChatHistoryResponse
+        {
+            Messages = messages.Select(m => new ChatHistoryMessageDto
+            {
+                Id = m.Id,
+                Role = m.Role,
+                Content = m.Content,
+                Timestamp = m.Timestamp
+            }).ToList()
+        };
+    }
+
+    public async Task<ChatResponse> SendAsync(ChatRequest request, Guid userId, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -52,11 +85,52 @@ public sealed class ChatAssistantService : IChatAssistantService
 
         _logger.LogInformation("Sending message through provider {Provider}", provider.ProviderKey);
 
+        // Business rule: one conversation per user per day (UTC)
+        var today = DateTime.UtcNow.Date;
+
+        var conversation = await _conversationRepository.GetTodayConversationAsync(userId);
+
+        if (conversation == null)
+        {
+            conversation = await _conversationRepository.CreateConversationAsync(userId, today);
+        }
+
+        // Save user message
+        var userMessage = new ConversationMessage
+        {
+            ConversationId = conversation.Id,
+            Role = "user",
+            Content = request.Message,
+            Timestamp = DateTime.UtcNow
+        };
+
+        await _conversationRepository.AddMessageAsync(userMessage);
+
+        // Build full history from DB
+        var history = await _conversationRepository.GetMessagesForConversationAsync(conversation.Id);
+
+        var historyForProvider = history.Select(m => new ChatMessage { Role = m.Role, Content = m.Content }).ToList();
+
+        // Append the new message to the history passed to provider
+        historyForProvider.Add(new ChatMessage { Role = userMessage.Role, Content = userMessage.Content });
+
+        // Call provider with full history
         var providerResponse = await provider.SendMessageAsync(
             request.Message,
             systemPrompt,
-            request.History,
+            historyForProvider,
             cancellationToken);
+
+        // Save assistant response
+        var assistantMessage = new ConversationMessage
+        {
+            ConversationId = conversation.Id,
+            Role = "assistant",
+            Content = providerResponse,
+            Timestamp = DateTime.UtcNow
+        };
+
+        await _conversationRepository.AddMessageAsync(assistantMessage);
 
         return new ChatResponse
         {

--- a/src/frontend/src/pages/Chat/index.tsx
+++ b/src/frontend/src/pages/Chat/index.tsx
@@ -1,23 +1,9 @@
 import { useState, useRef, useEffect, type FormEvent } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Send, Heart, Shield } from "lucide-react";
-import { api } from "../../services/api";
+import { sendChatMessage, getTodayMessages } from "../../services/chat";
 import "./Chat.css";
-
-interface Message {
-  id: number;
-  role: "user" | "ai";
-  text: string;
-}
-
-interface ChatResponse {
-  response: string;
-}
-
-interface ChatHistoryMessage {
-  role: string;
-  content: string;
-}
+import { ChatHistoryMessage, ChatHistoryMessageDto, Message } from "@/types/chat";
 
 const quickActions = [
   { label: "Estou me sentindo ansioso(a)", emoji: "😰" },
@@ -25,10 +11,6 @@ const quickActions = [
   { label: "Preciso conversar", emoji: "💬" },
 ];
 
-const DEFAULT_PROVIDER = "gemini";
-
-const fallbackResponse =
-  "Nao consegui falar com a API agora, mas continuo aqui com voce. Tente novamente em alguns instantes ou escreva de outro jeito o que esta sentindo.";
 
 const Chat = () => {
   const [messages, setMessages] = useState<Message[]>([
@@ -41,6 +23,7 @@ const Chat = () => {
   const [input, setInput] = useState("");
   const [isTyping, setIsTyping] = useState(false);
   const [isSending, setIsSending] = useState(false);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const typingTimeoutRef = useRef<number | null>(null);
@@ -59,6 +42,28 @@ const Chat = () => {
         window.clearTimeout(typingTimeoutRef.current);
       }
     };
+  }, []);
+
+  useEffect(() => {
+    const loadHistory = async () => {
+      try {
+        const response = await getTodayMessages();
+
+        if (response.messages.length > 0) {
+          setMessages(response.messages.map((message) => ({
+            id: message.id,
+            role: message.role === "user" ? "user" : "ai",
+            text: message.content,
+          })));
+        }
+      } catch {
+        // historico de chat falhou; manter mensagem inicial
+      } finally {
+        setIsLoadingHistory(false);
+      }
+    };
+
+    void loadHistory();
   }, []);
 
   const buildHistory = (nextUserMessage: string): ChatHistoryMessage[] => {
@@ -97,13 +102,7 @@ const Chat = () => {
     setIsSending(true);
 
     try {
-      const response = await api.post<ChatResponse>("/chat", {
-        provider: DEFAULT_PROVIDER,
-        message: trimmedText,
-        history: buildHistory(trimmedText),
-      });
-
-      const aiText = response.data.response?.trim() || fallbackResponse;
+      const aiText = await sendChatMessage(trimmedText, buildHistory(trimmedText));
 
       typingTimeoutRef.current = window.setTimeout(() => {
         setIsTyping(false);
@@ -119,7 +118,7 @@ const Chat = () => {
         setIsSending(false);
         setMessages((prev) => [
           ...prev,
-          { id: Date.now() + 1, role: "ai", text: fallbackResponse },
+          { id: Date.now() + 1, role: "ai", text: "Ocorreu um erro. Tente novamente." },
         ]);
       }, 700);
     }
@@ -163,23 +162,34 @@ const Chat = () => {
           {/* Messages */}
           <div className="chat-messages">
             <div className="chat-messages-inner">
-              <AnimatePresence initial={false}>
-                {messages.map((msg) => (
+                  <AnimatePresence initial={false}>
+                {isLoadingHistory ? (
                   <motion.div
-                    key={msg.id}
                     initial={{ opacity: 0, y: 16, scale: 0.96 }}
                     animate={{ opacity: 1, y: 0, scale: 1 }}
                     transition={{ duration: 0.4, ease: "easeOut" }}
-                    className={`chat-bubble-wrap ${msg.role}`}
+                    className="chat-loading"
                   >
-                    <div className={`chat-bubble ${msg.role}`}>
-                      {msg.role === "ai" && (
-                        <span className="chat-bubble-avatar">💙</span>
-                      )}
-                      <p>{msg.text}</p>
-                    </div>
+                    <div className="chat-loading-text">Carregando suas mensagens do dia...</div>
                   </motion.div>
-                ))}
+                ) : (
+                  messages.map((msg) => (
+                    <motion.div
+                      key={msg.id}
+                      initial={{ opacity: 0, y: 16, scale: 0.96 }}
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      transition={{ duration: 0.4, ease: "easeOut" }}
+                      className={`chat-bubble-wrap ${msg.role}`}
+                    >
+                      <div className={`chat-bubble ${msg.role}`}>
+                        {msg.role === "ai" && (
+                          <span className="chat-bubble-avatar">💙</span>
+                        )}
+                        <p>{msg.text}</p>
+                      </div>
+                    </motion.div>
+                  ))
+                )}
               </AnimatePresence>
 
               {/* Typing indicator */}

--- a/src/frontend/src/services/chat.ts
+++ b/src/frontend/src/services/chat.ts
@@ -1,0 +1,51 @@
+import { api } from "./api";
+import type { ChatHistoryMessage, ChatHistoryResponse, ChatResponse, Message } from "@/types/chat";
+import { getToken } from "./auth";
+
+const DEFAULT_PROVIDER = "gemini";
+
+const fallbackResponse =
+  "Nao consegui falar com a API agora, mas continuo aqui com voce. Tente novamente em alguns instantes ou escreva de outro jeito o que esta sentindo.";
+
+export const sendChatMessage = async (
+  message: string,
+  history: ChatHistoryMessage[]
+): Promise<string> => {
+  const token = getToken();
+
+  if (!token) {
+    throw new Error("Token não encontrado");
+  }
+
+  try {
+    const response = await api.post<ChatResponse>("/chat", {
+      provider: DEFAULT_PROVIDER,
+      message,
+      history,
+    }, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return response.data.response?.trim() || fallbackResponse;
+  } catch {
+    return fallbackResponse;
+  }
+};
+
+export const getTodayMessages = async (): Promise<ChatHistoryResponse> => {
+  const token = getToken();
+
+  if (!token) {
+    throw new Error("Token não encontrado");
+  }
+
+  const response = await api.get<ChatHistoryResponse>("/chat/history", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return response.data;
+};

--- a/src/frontend/src/types/chat.ts
+++ b/src/frontend/src/types/chat.ts
@@ -1,0 +1,25 @@
+export interface Message {
+  id: string | number;
+  role: "user" | "ai";
+  text: string;
+}
+
+export interface ChatResponse {
+  response: string;
+}
+
+export interface ChatHistoryMessage {
+  role: string;
+  content: string;
+}
+
+export interface ChatHistoryMessageDto {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+}
+
+export interface ChatHistoryResponse {
+  messages: ChatHistoryMessageDto[];
+}


### PR DESCRIPTION
Adiciona persistência de mensagens por usuário/dia no backend, com novas entidades, repositórios e migrations. Controller de chat agora exige autenticação e utiliza o ID do usuário do JWT. Frontend consulta e exibe histórico do dia ao abrir o chat, com serviço dedicado para envio e recuperação de mensagens.